### PR TITLE
Fix address and prev health number issues in enrolment

### DIFF
--- a/msp/package-lock.json
+++ b/msp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mygovbc-msp",
-  "version": "3.4.0",
+  "version": "3.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/msp/package.json
+++ b/msp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mygovbc-msp",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "MyGovBC MSP Service Provider Web App",
   "license": "Apache-2.0",
   "repository": {

--- a/msp/src/app/modules/enrolment/services/msp-api-enrolment.service.ts
+++ b/msp/src/app/modules/enrolment/services/msp-api-enrolment.service.ts
@@ -152,8 +152,8 @@ export class MspApiEnrolmentService extends BaseMspApiService {
       to.livedInBC.isPermanentMove = from.madePermanentMoveToBC === true ? 'Y' : 'N';
     }
 
-    if ( from.hasPreviousBCPhn ) {
-      to.livedInBC.prevHealthNumber = from.previousBCPhn;
+    if ( from.healthNumberFromOtherProvince ) {
+      to.livedInBC.prevHealthNumber = from.healthNumberFromOtherProvince;
     }
 
     if ( from.movedFromProvinceOrCountry ) {
@@ -277,6 +277,8 @@ export class MspApiEnrolmentService extends BaseMspApiService {
 
     if ( !application.mailingSameAsResidentialAddress ) {
       enrolee.mailingAddress = this.convertAddress( application.mailingAddress );
+    } else {
+      enrolee.mailingAddress = this.convertAddress( application.residentialAddress );
     }
 
     return enrolee;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Bug fix. `prevHealthNumber` should reference a health number from another province, not their previous BC PHN
Additionally, should their be no mailing address, their residential address will be filled in instead (for enrolment this time)

### Additional Notes:
