### PR TITLE
Review page info (part 1)

### DIFF
--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -367,35 +367,29 @@ export default {
             value: formatDate(child.canadaArrivalDate),
           });
         // }
-        // if (child.movedFrom) {
-          childData.push({
-            label: 'Moved from province/country',
-            value: `${child.movedFrom}`,
-          });
-        // }
         childData.push({
           label: 'Name changed?',
-          value: child.isNameChanged,
+          value: child.isNameChanged === 'Y' ? 'Yes' : 'No',
         });
         childData.push({
-          label: 'Name Change document type',
+          label: 'Name change document type',
           value: child.nameChangeSupportDocumentType,
         });
         childData.push({
           label: 'Lived in BC since birth?',
-          value: `${child.livedInBCSinceBirth}`,
+          value: child.livedInBCSinceBirth === 'Y' ? 'Yes' : 'No',
         });
         childData.push({
           label: 'Location child moved from:',
-          value: `${child.moveFromOrigin}`,
+          value: child.moveFromOrigin,
         });
         childData.push({
           label: 'Most recent date child moved to BC:',
-          value: child.recentBCMoveDate,
+          value: formatDate(child.recentBCMoveDate),
         });
         childData.push({
           label: 'Date child arrived in Canada:',
-          value: child.canadaArrivalDate,
+          value: formatDate(child.canadaArrivalDate),
         });
         childData.push({
           label: 'Health number from previous residence:',
@@ -403,7 +397,7 @@ export default {
         });
         // if (child.outsideBCLast12Months === 'Y') {
           childData.push({
-            label: 'Outside B.C. for more than 30 days',
+            label: 'Outside B.C. for more than 30 days in the last year?',
             value: 'Yes',
           });
           childData.push({
@@ -425,7 +419,7 @@ export default {
         // }
         childData.push({
           label: 'Has previous BC Health number?',
-          value: child.hasPreviousBCHealthNumber,
+          value: child.hasPreviousBCHealthNumber === 'Y' ? 'Yes' : 'No',
         });
         childData.push({
           label: 'Previous BC Health number?',
@@ -433,11 +427,11 @@ export default {
         });
         childData.push({
           label: 'Has child been released from institution?',
-          value: child.hasBeenReleasedFromInstitution,
+          value: child.hasBeenReleasedFromInstitution === 'Y' ? 'Yes' : 'No',
         });
         childData.push({
           label: 'Discharge date:',
-          value: child.dischargeDate,
+          value: formatDate(child.dischargeDate),
         });
         const isFullTimeStudent = child.ageRange === ChildAgeTypes.Child19To24;
         console.log("(ignore me)",isFullTimeStudent); //this is temporary. it keeps the IDE happy while I comment out the next line

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -355,51 +355,49 @@ export default {
           label: 'Support Document Type',
           value: child.citizenshipSupportDocumentType,
         });
-        // if (child.arrivalToBCDate) {
+        if (child.recentBCMoveDate) {
           childData.push({
             label: 'Date arrived in B.C.',
             value: formatDate(child.recentBCMoveDate),
           });
-        // }
-        // if (child.arrivalToCanadaDate) {
+        }
+        if (child.canadaArrivalDate) {
           childData.push({
             label: 'Date arrived in Canada',
             value: formatDate(child.canadaArrivalDate),
           });
-        // }
+        }
         childData.push({
           label: 'Name changed?',
           value: child.isNameChanged === 'Y' ? 'Yes' : 'No',
         });
-        childData.push({
-          label: 'Name change document type',
-          value: child.nameChangeSupportDocumentType,
-        });
+        if(child.isNameChanged === 'Y') {
+            childData.push({
+            label: 'Name change document type',
+            value: child.nameChangeSupportDocumentType,
+          });
+        }        
         childData.push({
           label: 'Lived in BC since birth?',
           value: child.livedInBCSinceBirth === 'Y' ? 'Yes' : 'No',
         });
-        childData.push({
-          label: 'Location child moved from:',
-          value: child.moveFromOrigin,
-        });
-        childData.push({
-          label: 'Most recent date child moved to BC:',
-          value: formatDate(child.recentBCMoveDate),
-        });
-        childData.push({
-          label: 'Date child arrived in Canada:',
-          value: formatDate(child.canadaArrivalDate),
-        });
-        childData.push({
-          label: 'Health number from previous residence:',
-          value: child.previousHealthNumber,
-        });
-        // if (child.outsideBCLast12Months === 'Y') {
-          childData.push({
-            label: 'Outside B.C. for more than 30 days in the last year?',
-            value: 'Yes',
+        if (child.livedInBCSinceBirth !== 'Y') {
+            childData.push({
+            label: 'Location child moved from:',
+            value: child.moveFromOrigin,
           });
+          if (child.previousHealthNumber) {
+            childData.push({
+              label: 'Health number from previous residence:',
+              value: child.previousHealthNumber,
+            });
+          }
+        }
+        childData.push({
+          label: 'Outside B.C. for more than 30 days in the last year?',
+          value: child.outsideBCLast12Months === 'Y' ? 'Yes' : 'No',
+        });
+        if (child.outsideBCLast12Months === 'Y') {
           childData.push({
             label: 'Reason for leaving',
             value: child.outsideBCLast12MonthsReason,
@@ -416,30 +414,33 @@ export default {
             label: 'Return date',
             value: formatDate(child.outsideBCLast12MonthsReturnDate),
           });
-        // }
+        }
         childData.push({
           label: 'Has previous BC Health number?',
           value: child.hasPreviousBCHealthNumber === 'Y' ? 'Yes' : 'No',
         });
-        childData.push({
-          label: 'Previous BC Health number?',
-          value: child.previousBCHealthNumber,
-        });
+        if (child.hasPreviousBCHealthNumber === 'Y') {
+            childData.push({
+            label: 'Previous BC Health number?',
+            value: child.previousBCHealthNumber,
+          });
+        }        
         childData.push({
           label: 'Has child been released from institution?',
           value: child.hasBeenReleasedFromInstitution === 'Y' ? 'Yes' : 'No',
         });
-        childData.push({
+        if (child.hasBeenReleasedFromInstitution === 'Y') {
+          childData.push({
           label: 'Discharge date:',
           value: formatDate(child.dischargeDate),
         });
+        }        
         const isFullTimeStudent = child.ageRange === ChildAgeTypes.Child19To24;
-        console.log("(ignore me)",isFullTimeStudent); //this is temporary. it keeps the IDE happy while I comment out the next line
-        // if (isFullTimeStudent) {
-          childData.push({
-            label: 'Full-time student',
-            value: 'Yes',
-          });
+        childData.push({
+          label: 'Full-time student',
+          value: isFullTimeStudent ? 'Yes' : 'No',
+        });
+        if (isFullTimeStudent) {
           const willResideInBC = child.willResideInBCAfterStudies === 'Y';
           childData.push({
             label: 'Will you reside in BC upon completion of your studies',
@@ -479,18 +480,17 @@ export default {
           });
           childData.push({
             label: 'School departure date:',
-            value: child.schoolDepartureDate,
+            value: formatDate(child.schoolDepartureDate),
           });
           childData.push({
             label: 'Estimated school completion date:',
-            value: child.schoolCompletionDate,
+            value: formatDate(child.schoolCompletionDate),
           });
-        // }
+        }
         const documentCount = child.citizenshipSupportDocuments.length + child.nameChangeSupportDocuments.length;
-        const fileLabel = ' file' + documentCount > 1 ? 's' : '';
         childData.push({
           label: 'Documents',
-          value: documentCount + fileLabel,
+          value: `${documentCount} ${this.getFilePlural(documentCount)}`,
         });
         chldrnData.push(childData);
       }

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -466,10 +466,12 @@ export default {
         label: `Account Holder net income for ${selectedYear}`,
         value: moneyFormatter.format(this.$store.state.enrolmentModule.ahSBIncome),
       });
-      items.push({
-        label: `Spouse/common-law partner's net income from ${selectedYear}`,
-        value: moneyFormatter.format(this.$store.state.enrolmentModule.spouseSBIncome),
-      });
+      if (this.$store.state.enrolmentModule.hasSpouse === "Y"){
+        items.push({
+          label: `Spouse/common-law partner's net income from ${selectedYear}`,
+          value: moneyFormatter.format(this.$store.state.enrolmentModule.spouseSBIncome),
+        });
+      }
       items.push({
         label: `Number of children on MSP account`,
         value: this.$store.state.enrolmentModule.numChildren,

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -471,7 +471,7 @@ export default {
       });
       items.push({
         label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
-        value: this.$store.state.enrolmentModule.hasDisabilityCredit,
+        value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
       items.push({
         label: `Who claimed`,
@@ -479,11 +479,11 @@ export default {
       });
       items.push({
         label: `Registered Disability Savings Plan?`,
-        value: this.$store.state.enrolmentModule.hasRDSP,
+        value: this.$store.state.enrolmentModule.hasRDSP === 'Y' ? 'Yes' : 'No',
       });
       items.push({
         label: `Claimed attendant or nursing home expenses`,
-        value: this.$store.state.enrolmentModule.hasAttendantNursingExpenses,
+        value: this.$store.state.enrolmentModule.hasAttendantNursingExpenses === 'Y' ?  'Yes' : 'No',
       });
       items.push({
         label: `Who claimed`,

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -463,11 +463,11 @@ export default {
       const items = [];
       items.push({
         label: `Account Holder net income for ${this.$store.state.enrolmentModule.selectedNOAYear}`,
-        value: this.$store.state.enrolmentModule.ahSBIncome,
+        value: moneyFormatter.format(this.$store.state.enrolmentModule.ahSBIncome),
       });
       items.push({
         label: `Spouse/common-law partner's net income from ${this.$store.state.enrolmentModule.selectedNOAYear}`,
-        value: this.$store.state.enrolmentModule.ahSBIncome,
+        value: moneyFormatter.format(this.$store.state.enrolmentModule.ahSBIncome),
       });
       items.push({
         label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
@@ -489,11 +489,12 @@ export default {
         label: `Who claimed`,
         value: this.$store.state.enrolmentModule.selectedAttendantNursingRecipients,
       });
+      const documentCount = this.$store.state.enrolmentModule.attendantNursingReceipts.length;
+      const fileLabel = (documentCount > 1) ? 's' : '';
       items.push({
-        label: `Documents uploaded`,
-        value: this.$store.state.enrolmentModule.attendantNursingReceipts,
+        label: 'Documents',
+        value: documentCount + ' file' + fileLabel
       });
-      
       return items;
     },
     contactData() {

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -474,10 +474,12 @@ export default {
         label: `Claimed disability tax credit in ${selectedYear}`,
         value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
-      items.push({
-        label: `Who claimed`,
-        value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedDisabilityRecipients),
-      });
+      if (this.$store.state.enrolmentModule.selectedDisabilityRecipients.length > 0){
+        items.push({
+          label: `Who claimed`,
+          value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedDisabilityRecipients),
+        });
+      }
       items.push({
         label: `Registered Disability Savings Plan?`,
         value: this.$store.state.enrolmentModule.hasRDSP === 'Y' ? 'Yes' : 'No',
@@ -486,10 +488,12 @@ export default {
         label: `Claimed attendant or nursing home expenses`,
         value: this.$store.state.enrolmentModule.hasAttendantNursingExpenses === 'Y' ?  'Yes' : 'No',
       });
-      items.push({
-        label: `Who claimed`,
-        value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedAttendantNursingRecipients),
-      });
+      if (this.$store.state.enrolmentModule.selectedAttendantNursingRecipients.length > 0){
+          items.push({
+          label: `Who claimed`,
+          value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedAttendantNursingRecipients),
+        });
+      }
       const documentCount = this.$store.state.enrolmentModule.attendantNursingReceipts.length;
       items.push({
         label: 'Documents',

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -461,16 +461,17 @@ export default {
     },
     suppBenData() {
       const items = [];
+      const selectedYear = this.$store.state.enrolmentModule.selectedNOAYear;
       items.push({
-        label: `Account Holder net income for ${this.$store.state.enrolmentModule.selectedNOAYear}`,
+        label: `Account Holder net income for ${selectedYear}`,
         value: moneyFormatter.format(this.$store.state.enrolmentModule.ahSBIncome),
       });
       items.push({
-        label: `Spouse/common-law partner's net income from ${this.$store.state.enrolmentModule.selectedNOAYear}`,
-        value: moneyFormatter.format(this.$store.state.enrolmentModule.ahSBIncome),
+        label: `Spouse/common-law partner's net income from ${selectedYear}`,
+        value: moneyFormatter.format(this.$store.state.enrolmentModule.spouseSBIncome),
       });
       items.push({
-        label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
+        label: `Claimed disability tax credit in ${selectedYear}`,
         value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
       items.push({
@@ -490,10 +491,9 @@ export default {
         value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedAttendantNursingRecipients),
       });
       const documentCount = this.$store.state.enrolmentModule.attendantNursingReceipts.length;
-      const fileLabel = (documentCount > 1) ? 's' : '';
       items.push({
         label: 'Documents',
-        value: documentCount + ' file' + fileLabel
+        value: `${documentCount} ${this.getFilePlural(documentCount)}`,
       });
       return items;
     },
@@ -649,6 +649,10 @@ export default {
       }
       return result;
     },
+    getFilePlural(count) {
+      //takes an integer, returns single or plural form of word
+      return (count > 1) ? 'files' : 'file';
+    }
   }
 }
 </script>

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -473,9 +473,31 @@ export default {
         label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
         value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
+      const disabilityRecipients = this.$store.state.enrolmentModule.selectedDisabilityRecipients;
+      let newDisabilityRecipients = "";
+      for (const [index, recipient] of disabilityRecipients.entries()) {
+        switch (recipient) {
+          case "ah":
+            newDisabilityRecipients += `Account Holder`;
+          break;
+          case "spouse":
+            newDisabilityRecipients += `Spouse`;
+          break;
+          case "child":
+            newDisabilityRecipients += `Child`;
+          break;
+        
+        default:
+          newDisabilityRecipients += `${recipient}`;
+        }
+        if (index !== disabilityRecipients.length - 1) {
+          newDisabilityRecipients += ","
+        }
+        newDisabilityRecipients += " "
+      } 
       items.push({
         label: `Who claimed`,
-        value: this.$store.state.enrolmentModule.selectedDisabilityRecipients,
+        value: newDisabilityRecipients,
       });
       items.push({
         label: `Registered Disability Savings Plan?`,

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -462,36 +462,36 @@ export default {
     suppBenData() {
       const items = [];
       items.push({
-        label: `Account Holder net income for ${this.$store.state.enrolmentModule.ahFPCIncome}`,
-        value: "space "+this.$store.state.enrolmentModule.ahFPCIncome,
+        label: `Account Holder net income for ${this.$store.state.enrolmentModule.selectedNOAYear}`,
+        value: this.$store.state.enrolmentModule.ahSBIncome,
       });
       items.push({
-        label: `Spouse/common-law partner's net income from 2020`,
-        value: "space "+this.$store.state.enrolmentModule.setSpouseSBIncome,
+        label: `Spouse/common-law partner's net income from ${this.$store.state.enrolmentModule.selectedNOAYear}`,
+        value: this.$store.state.enrolmentModule.ahSBIncome,
       });
       items.push({
-        label: `Claimed disability tax credit in 2020`,
-        value: "space "+this.$store.state.enrolmentModule.setHasDisabilityCredit,
+        label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
+        value: this.$store.state.enrolmentModule.hasDisabilityCredit,
       });
       items.push({
         label: `Who claimed`,
-        value: "space "+this.$store.state.enrolmentModule.setSelectedDisabilityRecipients,
+        value: this.$store.state.enrolmentModule.selectedDisabilityRecipients,
       });
       items.push({
         label: `Registered Disability Savings Plan?`,
-        value: "space "+this.$store.state.enrolmentModule.setHasRDSP,
+        value: this.$store.state.enrolmentModule.hasRDSP,
       });
       items.push({
         label: `Claimed attendant or nursing home expenses`,
-        value: "space "+this.$store.state.enrolmentModule.setHasAttendantNursingExpenses,
+        value: this.$store.state.enrolmentModule.hasAttendantNursingExpenses,
       });
       items.push({
         label: `Who claimed`,
-        value: "space "+this.$store.state.enrolmentModule.setSelectedAttendantNursingRecipients,
+        value: this.$store.state.enrolmentModule.selectedAttendantNursingRecipients,
       });
       items.push({
         label: `Documents uploaded`,
-        value: "space "+this.$store.state.enrolmentModule.setAttendantNursingReceipts,
+        value: this.$store.state.enrolmentModule.attendantNursingReceipts,
       });
       
       return items;

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -471,6 +471,16 @@ export default {
         value: moneyFormatter.format(this.$store.state.enrolmentModule.spouseSBIncome),
       });
       items.push({
+        label: `Number of children on MSP account`,
+        value: this.$store.state.enrolmentModule.numChildren,
+      });
+      if (this.$store.state.enrolmentModule.hasChildren === "Y") {
+          items.push({
+          label: `Claimed childcare expenses`,
+          value: moneyFormatter.format(this.$store.state.enrolmentModule.claimedChildCareExpenses),
+        });
+      }
+      items.push({
         label: `Claimed disability tax credit in ${selectedYear}`,
         value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
@@ -480,10 +490,23 @@ export default {
           value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedDisabilityRecipients),
         });
       }
+      if (this.$store.state.enrolmentModule.hasChildren === "Y" && this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y') {
+          items.push({
+          label: `Number of children eligible for a disability tax credit`,
+          value: this.$store.state.enrolmentModule.numDisabilityChildren,
+        });
+      }
       items.push({
         label: `Registered Disability Savings Plan?`,
-        value: this.$store.state.enrolmentModule.hasRDSP === 'Y' ? 'Yes' : 'No',
+        value: this.$store.state.enrolmentModule.hasRDSP === "Y" ? "Yes" : "No",
       });
+      if (this.$store.state.enrolmentModule.hasRDSP === "Y") {
+        items.push({
+          label: `RDSP amount`,
+          value: moneyFormatter.format(this.$store.state.enrolmentModule.sbRDSPAmount),
+        });
+      }
+      
       items.push({
         label: `Claimed attendant or nursing home expenses`,
         value: this.$store.state.enrolmentModule.hasAttendantNursingExpenses === 'Y' ?  'Yes' : 'No',
@@ -492,6 +515,12 @@ export default {
           items.push({
           label: `Who claimed`,
           value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedAttendantNursingRecipients),
+        });
+      }
+      if (this.$store.state.enrolmentModule.hasChildren === "Y" && this.$store.state.enrolmentModule.hasAttendantNursingExpenses === 'Y') {
+        items.push({
+          label: `Number of children claiming attendant care expenses`,
+          value: this.$store.state.enrolmentModule.numAttendantNursingChildren,
         });
       }
       const documentCount = this.$store.state.enrolmentModule.attendantNursingReceipts.length;
@@ -655,7 +684,7 @@ export default {
     },
     getFilePlural(count) {
       //takes an integer, returns single or plural form of word
-      return (count > 1) ? 'files' : 'file';
+      return (count === 1) ? 'file' : 'files';
     }
   }
 }

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -351,25 +351,57 @@ export default {
           label: 'Status in Canada',
           value: statusInCanada,
         });
-        if (child.arrivalToBCDate) {
+        childData.push({
+          label: 'Support Document Type',
+          value: child.citizenshipSupportDocumentType,
+        });
+        // if (child.arrivalToBCDate) {
           childData.push({
             label: 'Date arrived in B.C.',
-            value: formatDate(child.arrivalToBCDate),
+            value: formatDate(child.recentBCMoveDate),
           });
-        }
-        if (child.arrivalToCanadaDate) {
+        // }
+        // if (child.arrivalToCanadaDate) {
           childData.push({
             label: 'Date arrived in Canada',
-            value: formatDate(child.arrivalToCanadaDate),
+            value: formatDate(child.canadaArrivalDate),
           });
-        }
-        if (child.movedFrom) {
+        // }
+        // if (child.movedFrom) {
           childData.push({
             label: 'Moved from province/country',
-            value: child.movedFrom,
+            value: `${child.movedFrom}`,
           });
-        }
-        if (child.outsideBCLast12Months === 'Y') {
+        // }
+        childData.push({
+          label: 'Name changed?',
+          value: child.isNameChanged,
+        });
+        childData.push({
+          label: 'Name Change document type',
+          value: child.nameChangeSupportDocumentType,
+        });
+        childData.push({
+          label: 'Lived in BC since birth?',
+          value: `${child.livedInBCSinceBirth}`,
+        });
+        childData.push({
+          label: 'Location child moved from:',
+          value: `${child.moveFromOrigin}`,
+        });
+        childData.push({
+          label: 'Most recent date child moved to BC:',
+          value: child.recentBCMoveDate,
+        });
+        childData.push({
+          label: 'Date child arrived in Canada:',
+          value: child.canadaArrivalDate,
+        });
+        childData.push({
+          label: 'Health number from previous residence:',
+          value: child.previousHealthNumber,
+        });
+        // if (child.outsideBCLast12Months === 'Y') {
           childData.push({
             label: 'Outside B.C. for more than 30 days',
             value: 'Yes',
@@ -390,9 +422,26 @@ export default {
             label: 'Return date',
             value: formatDate(child.outsideBCLast12MonthsReturnDate),
           });
-        }
+        // }
+        childData.push({
+          label: 'Has previous BC Health number?',
+          value: child.hasPreviousBCHealthNumber,
+        });
+        childData.push({
+          label: 'Previous BC Health number?',
+          value: child.previousBCHealthNumber,
+        });
+        childData.push({
+          label: 'Has child been released from institution?',
+          value: child.hasBeenReleasedFromInstitution,
+        });
+        childData.push({
+          label: 'Discharge date:',
+          value: child.dischargeDate,
+        });
         const isFullTimeStudent = child.ageRange === ChildAgeTypes.Child19To24;
-        if (isFullTimeStudent) {
+        console.log("(ignore me)",isFullTimeStudent); //this is temporary. it keeps the IDE happy while I comment out the next line
+        // if (isFullTimeStudent) {
           childData.push({
             label: 'Full-time student',
             value: 'Yes',
@@ -434,7 +483,15 @@ export default {
             label: 'Country',
             value: child.schoolCountry,
           });
-        }
+          childData.push({
+            label: 'School departure date:',
+            value: child.schoolDepartureDate,
+          });
+          childData.push({
+            label: 'Estimated school completion date:',
+            value: child.schoolCompletionDate,
+          });
+        // }
         const documentCount = child.citizenshipSupportDocuments.length + child.nameChangeSupportDocuments.length;
         const fileLabel = ' file' + documentCount > 1 ? 's' : '';
         childData.push({

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -598,8 +598,14 @@ export default {
         items.push({
           label: 'Country',
           value: this.$store.state.enrolmentModule.mailCountry,
-        });
+        });       
       }
+      if (this.$store.state.enrolmentModule.phone) {
+          items.push({
+          label: 'Phone',
+          value: this.$store.state.enrolmentModule.phone,
+        });
+      } 
       return items;
     },
   },

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -461,6 +461,39 @@ export default {
     },
     suppBenData() {
       const items = [];
+      items.push({
+        label: `Account Holder net income for ${this.$store.state.enrolmentModule.ahFPCIncome}`,
+        value: "space "+this.$store.state.enrolmentModule.ahFPCIncome,
+      });
+      items.push({
+        label: `Spouse/common-law partner's net income from 2020`,
+        value: "space "+this.$store.state.enrolmentModule.setSpouseSBIncome,
+      });
+      items.push({
+        label: `Claimed disability tax credit in 2020`,
+        value: "space "+this.$store.state.enrolmentModule.setHasDisabilityCredit,
+      });
+      items.push({
+        label: `Who claimed`,
+        value: "space "+this.$store.state.enrolmentModule.setSelectedDisabilityRecipients,
+      });
+      items.push({
+        label: `Registered Disability Savings Plan?`,
+        value: "space "+this.$store.state.enrolmentModule.setHasRDSP,
+      });
+      items.push({
+        label: `Claimed attendant or nursing home expenses`,
+        value: "space "+this.$store.state.enrolmentModule.setHasAttendantNursingExpenses,
+      });
+      items.push({
+        label: `Who claimed`,
+        value: "space "+this.$store.state.enrolmentModule.setSelectedAttendantNursingRecipients,
+      });
+      items.push({
+        label: `Documents uploaded`,
+        value: "space "+this.$store.state.enrolmentModule.setAttendantNursingReceipts,
+      });
+      
       return items;
     },
     contactData() {

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -473,31 +473,9 @@ export default {
         label: `Claimed disability tax credit in ${this.$store.state.enrolmentModule.selectedNOAYear}`,
         value: this.$store.state.enrolmentModule.hasDisabilityCredit === 'Y' ? 'Yes' : 'No',
       });
-      const disabilityRecipients = this.$store.state.enrolmentModule.selectedDisabilityRecipients;
-      let newDisabilityRecipients = "";
-      for (const [index, recipient] of disabilityRecipients.entries()) {
-        switch (recipient) {
-          case "ah":
-            newDisabilityRecipients += `Account Holder`;
-          break;
-          case "spouse":
-            newDisabilityRecipients += `Spouse`;
-          break;
-          case "child":
-            newDisabilityRecipients += `Child`;
-          break;
-        
-        default:
-          newDisabilityRecipients += `${recipient}`;
-        }
-        if (index !== disabilityRecipients.length - 1) {
-          newDisabilityRecipients += ","
-        }
-        newDisabilityRecipients += " "
-      } 
       items.push({
         label: `Who claimed`,
-        value: newDisabilityRecipients,
+        value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedDisabilityRecipients),
       });
       items.push({
         label: `Registered Disability Savings Plan?`,
@@ -509,7 +487,7 @@ export default {
       });
       items.push({
         label: `Who claimed`,
-        value: this.$store.state.enrolmentModule.selectedAttendantNursingRecipients,
+        value: this.getWhoClaimed(this.$store.state.enrolmentModule.selectedAttendantNursingRecipients),
       });
       const documentCount = this.$store.state.enrolmentModule.attendantNursingReceipts.length;
       const fileLabel = (documentCount > 1) ? 's' : '';
@@ -646,7 +624,31 @@ export default {
         return `Child #${index + 1}`;
       }
       return 'Child';
-    }
+    },
+    getWhoClaimed(array) {
+      //takes an array containing some combination of the values ah, spouse, and child
+      //returns a new string of those same array entries but capitalized, fully spelled out, and comma separated
+      let result = "";
+      for (const [index, recipient] of array.entries()) {
+        switch (recipient) {
+          case "ah":
+            result += `Account Holder`;
+            break;
+          case "spouse":
+            result += `Spouse`;
+            break;
+          case "child":
+            result += `Child`;
+            break;
+          default:
+            result += `${recipient}`;
+        }
+        if (index !== array.length - 1) {
+          result += ", ";
+        }
+      }
+      return result;
+    },
   }
 }
 </script>

--- a/jha/src/views/enrolment/ContactInfoPage.vue
+++ b/jha/src/views/enrolment/ContactInfoPage.vue
@@ -168,13 +168,13 @@
                 v-if="$v.mailProvince.$dirty && !$v.mailProvince.provinceContentValidator"
                 aria-live="assertive">Province or State must contain letters and may include special characters such as hyphens, periods, apostrophes, and blank characters.</div>
               <CountrySelect class="mt-3"
-                label="Country"
+                label="Jurisdiction"
                 id="mail-country"
                 v-model="mailCountry"
                 :inputStyle='mediumStyles'
                 :disablePlaceholder="true"
                 @blur="handleBlurField($v.mailCountry)" />
-              <div class="text-danger" v-if="$v.mailCountry.$dirty && !$v.mailCountry.required" aria-live="assertive">Country is required.</div>
+              <div class="text-danger" v-if="$v.mailCountry.$dirty && !$v.mailCountry.required" aria-live="assertive">Jurisdiction is required.</div>
 
               <div v-if="mailCountry === 'Canada'">
                 <PostalCodeInput 

--- a/jha/src/views/enrolment/SuppBenInfoPage.vue
+++ b/jha/src/views/enrolment/SuppBenInfoPage.vue
@@ -533,18 +533,22 @@ export default {
         this.numChildren = 0;
         this.numDisabilityChildren = 0;
         this.numAttendantNursingChildren = 0;
-        this.claimedChildCareExpenses = 0;
+        this.claimedChildCareExpenses = "0";
       }
 
       if (this.numChildren === 0) {
         this.hasChildren = "N";
         this.numDisabilityChildren = 0;
         this.numAttendantNursingChildren = 0;
-        this.claimedChildCareExpenses = 0;
+        this.claimedChildCareExpenses = "0";
       }
 
       if (this.hasAttendantNursingExpenses === "N") {
         this.attendantNursingReceipts = [];
+      }
+
+      if (this.$store.state.enrolmentModule.hasRDSP === "N") {
+        this.$store.state.enrolmentModule.sbRDSPAmount = "0";
       }
     },
     saveData() {

--- a/jha/src/views/enrolment/SuppBenInfoPage.vue
+++ b/jha/src/views/enrolment/SuppBenInfoPage.vue
@@ -547,8 +547,12 @@ export default {
         this.attendantNursingReceipts = [];
       }
 
-      if (this.$store.state.enrolmentModule.hasRDSP === "N") {
-        this.$store.state.enrolmentModule.sbRDSPAmount = "0";
+      if (this.hasRDSP === "N") {
+        this.sbRDSPAmount = "0";
+      }
+
+      if (this.hasSpouse === "N") {
+        this.spouseSBIncome = "0";
       }
     },
     saveData() {

--- a/jha/src/views/enrolment/SuppBenInfoPage.vue
+++ b/jha/src/views/enrolment/SuppBenInfoPage.vue
@@ -528,7 +528,27 @@ export default {
     return validations;
   },
   methods: {
+    correlateData() {
+      if (this.hasChildren === "N") {
+        this.numChildren = 0;
+        this.numDisabilityChildren = 0;
+        this.numAttendantNursingChildren = 0;
+        this.claimedChildCareExpenses = 0;
+      }
+
+      if (this.numChildren === 0) {
+        this.hasChildren = "N";
+        this.numDisabilityChildren = 0;
+        this.numAttendantNursingChildren = 0;
+        this.claimedChildCareExpenses = 0;
+      }
+
+      if (this.hasAttendantNursingExpenses === "N") {
+        this.attendantNursingReceipts = [];
+      }
+    },
     saveData() {
+      this.correlateData();
       this.$store.dispatch(`${enrolmentModule}/${SET_SELECTED_NOA_YEAR}`, this.selectedNOAYear);
       this.$store.dispatch(`${enrolmentModule}/${SET_AH_SB_INCOME}`, this.ahSBIncome);
       this.$store.dispatch(`${enrolmentModule}/${SET_SPOUSE_SB_INCOME}`, this.spouseSBIncome);
@@ -635,14 +655,23 @@ export default {
         this.selectOptionsFamilyMembers.filter(option => {return option.id === "child";} )[0].disabled = false;
       }
     },
-    hasDisabilityCredit(value) {
+    hasDisabilityCredit(value) {  
       if (this.pageLoaded && value === 'N') {
         this.selectedDisabilityRecipients = [];
+        this.numDisabilityChildren = 0;
+        this.$v.selectedDisabilityRecipients.$reset()
+        this.$v.numDisabilityChildren.$reset()
       }
     },
     hasAttendantNursingExpenses(value) {
       if (this.pageLoaded && value === 'N') {
         this.selectedAttendantNursingRecipients = [];
+        this.numAttendantNursingChildren = 0;
+        //could clear this.attendantNursingReceipts = [] if we wanted as well
+        //I'm leaving it out right now to save on the effort of re-uploading
+        this.$v.selectedAttendantNursingRecipients.$reset()
+        this.$v.numAttendantNursingChildren.$reset()
+        this.$v.attendantNursingReceipts.$reset()
       }
     }
   },

--- a/jha/src/views/enrolment/SuppBenInfoPage.vue
+++ b/jha/src/views/enrolment/SuppBenInfoPage.vue
@@ -529,30 +529,48 @@ export default {
   },
   methods: {
     correlateData() {
+      //No Spouse
+      if (this.hasSpouse === "N") {
+        this.spouseSBIncome = "0";
+      }
+
+      //No children
       if (this.hasChildren === "N") {
-        this.numChildren = 0;
-        this.numDisabilityChildren = 0;
-        this.numAttendantNursingChildren = 0;
+        this.numChildren = "0";
+        this.numDisabilityChildren = "0";
+        this.numAttendantNursingChildren = "0";
         this.claimedChildCareExpenses = "0";
       }
 
       if (this.numChildren === 0) {
         this.hasChildren = "N";
-        this.numDisabilityChildren = 0;
-        this.numAttendantNursingChildren = 0;
+        this.numDisabilityChildren = "0";
+        this.numAttendantNursingChildren = "0";
         this.claimedChildCareExpenses = "0";
       }
 
+      //No children in recipients list
+      if (!this.selectedDisabilityRecipients.includes("child")) {
+        this.numDisabilityChildren = "0";
+      }
+
+      if (!this.selectedAttendantNursingRecipients.includes("child")) {
+        this.numAttendantNursingChildren = "0";
+      }
+
+      //No expenses/credits
       if (this.hasAttendantNursingExpenses === "N") {
         this.attendantNursingReceipts = [];
+        this.selectedAttendantNursingRecipients = [];
       }
 
+      if (this.hasDisabilityCredit === "N") {
+        this.selectedDisabilityRecipients = [];
+      }
+
+      //No RDSP
       if (this.hasRDSP === "N") {
         this.sbRDSPAmount = "0";
-      }
-
-      if (this.hasSpouse === "N") {
-        this.spouseSBIncome = "0";
       }
     },
     saveData() {

--- a/jha/src/views/enrolment/SuppBenInfoPage.vue
+++ b/jha/src/views/enrolment/SuppBenInfoPage.vue
@@ -655,23 +655,23 @@ export default {
         this.selectOptionsFamilyMembers.filter(option => {return option.id === "child";} )[0].disabled = false;
       }
     },
-    hasDisabilityCredit(value) {  
-      if (this.pageLoaded && value === 'N') {
+    hasDisabilityCredit(value) {
+      if (this.pageLoaded && value === "N") {
         this.selectedDisabilityRecipients = [];
         this.numDisabilityChildren = 0;
-        this.$v.selectedDisabilityRecipients.$reset()
-        this.$v.numDisabilityChildren.$reset()
+        this.$v.selectedDisabilityRecipients.$reset();
+        this.$v.numDisabilityChildren.$reset();
       }
     },
     hasAttendantNursingExpenses(value) {
-      if (this.pageLoaded && value === 'N') {
+      if (this.pageLoaded && value === "N") {
         this.selectedAttendantNursingRecipients = [];
         this.numAttendantNursingChildren = 0;
         //could clear this.attendantNursingReceipts = [] if we wanted as well
         //I'm leaving it out right now to save on the effort of re-uploading
-        this.$v.selectedAttendantNursingRecipients.$reset()
-        this.$v.numAttendantNursingChildren.$reset()
-        this.$v.attendantNursingReceipts.$reset()
+        this.$v.selectedAttendantNursingRecipients.$reset();
+        this.$v.numAttendantNursingChildren.$reset();
+        this.$v.attendantNursingReceipts.$reset();
       }
     }
   },


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [] Unit tests for these changes were added (if applicable) 
I want tests to exist for this in the long term, but it'd probably be better to do them all at once when the app is a bit more stable
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):

- Add a bunch of new fields to the ReviewTableList.vue file 
(this is after I did a pretty thorough review of the fields asked for and stored in the data, and to my knowledge everything is there. wording is temporary and will probably be changed later) 
- Ernesto said the intention was to show the user all of the data they had input, so I also moved some info slightly, eg. it always says the answer to the question "is this child a full-time student", not just when they answer yes (see line 443 of new version in changes below)
- Added getWhoClaimed() function to take an array of recipients and return a capitalized, nicely formatted string
- Added getFilePlural() function to make it easier to pluralize the word "file" as needed
- I also fixed a country -> jurisdiction instance when I saw it
- Added correlateData() function to make sure data is consistent with itself before it gets dispatched to the store.  This is run just before the user navigates from the page when the data is in a generally final state. This also ensures that data that reaches the Review table is displayed properly
- I also added a few clauses to the watcher functions. This way whenever a person turns disabilityCredit or attendantNursingExpenses to no, it'll clear the recipients and number of affected children right away. If we don't want this to happen right away, it can also happen before dispatch in the correlateData() function

### Additional Notes:
Feel free to check out the comments in tickets JHA-124, 125, and 177 for screenshots on how these sections look now.