### PR TITLE
Bug fix: PHN first digit validation

### DIFF
--- a/jha/src/components/enrolment/Child.vue
+++ b/jha/src/components/enrolment/Child.vue
@@ -1103,9 +1103,7 @@ export default {
         birthDateYouthValidator: optionalValidator(birthDateYouthValidator),
         birthDateStudentValidator: optionalValidator(birthDateStudentValidator),
       },
-      personalHealthNumber: {
-        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator)
-      },
+      personalHealthNumber: {},
       gender: {},
       status: {},
       statusReason: {},
@@ -1149,6 +1147,7 @@ export default {
     if (this.requestPersonalHealthNumber) {
       validations.personalHealthNumber.required = required;
       validations.personalHealthNumber.phnValidator = optionalValidator(phnValidator);
+      validations.personalHealthNumber.phnFirstDigitValidator = optionalValidator(phnFirstDigitValidator);
     }
     
     if (this.requestGender) {

--- a/jha/src/components/enrolment/Child.vue
+++ b/jha/src/components/enrolment/Child.vue
@@ -94,7 +94,7 @@
           v-if="$v.personalHealthNumber.$dirty && !$v.personalHealthNumber.required"
           aria-live="assertive">Personal Health Number is required.</div>
         <div class="text-danger"
-          v-if="$v.personalHealthNumber.$dirty && !$v.personalHealthNumber.phnValidator"
+          v-if="$v.personalHealthNumber.$dirty && (!$v.personalHealthNumber.phnValidator || !$v.personalHealthNumber.phnFirstDigitValidator)"
           aria-live="assertive">Personal Health Number is invalid.</div>
       </div>
       <div v-if="requestGender">
@@ -762,6 +762,7 @@ import {
   nonCanadaValidator,
   reasonDestinationContentValidator,
   pastDateValidator,
+  phnFirstDigitValidator,
 } from '@/helpers/validators';
 import {
   CountrySelect,
@@ -1102,7 +1103,9 @@ export default {
         birthDateYouthValidator: optionalValidator(birthDateYouthValidator),
         birthDateStudentValidator: optionalValidator(birthDateStudentValidator),
       },
-      personalHealthNumber: {},
+      personalHealthNumber: {
+        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator)
+      },
       gender: {},
       status: {},
       statusReason: {},

--- a/jha/src/helpers/validators.js
+++ b/jha/src/helpers/validators.js
@@ -83,7 +83,6 @@ export const reasonDestinationContentValidator = (value) => {
 
 export const phnFirstDigitValidator = (value) => {
   if (typeof(value) !== 'string') {
-    console.log("phnFirstDigitValidator was passed a non-string")
     return false;
   }
   return value[0] === '9';

--- a/jha/src/helpers/validators.js
+++ b/jha/src/helpers/validators.js
@@ -80,3 +80,11 @@ export const reasonDestinationContentValidator = (value) => {
   return criteriaAllowedCharecters.test(value)
           && criteriaMustHaveLetter.test(value);
 };
+
+export const phnFirstDigitValidator = (value) => {
+  if (typeof(value) !== 'string') {
+    console.log("phnFirstDigitValidator was passed a non-string")
+    return false;
+  }
+  return value[0] === '9';
+};

--- a/jha/src/views/enrolment/PersonalInfoPage.vue
+++ b/jha/src/views/enrolment/PersonalInfoPage.vue
@@ -91,7 +91,7 @@
             aria-live="assertive">Personal Health Number is required.</div>
           <div class="text-danger"
             v-if="$v.personalHealthNumber.$dirty
-              && !$v.personalHealthNumber.phnValidator"
+              && (!$v.personalHealthNumber.phnValidator || !$v.personalHealthNumber.phnFirstDigitValidator)"
             aria-live="assertive">Personal Health Number is invalid.</div>
         </div>
         <div v-if="requestSocialInsuranceNumber">
@@ -708,6 +708,7 @@ import {
   nameValidator,
   nonBCValidator,
   pastDateValidator,
+  phnFirstDigitValidator,
   yesValidator,
   optionalInvalidDateValidator,
   reasonDestinationContentValidator,
@@ -904,7 +905,9 @@ export default {
         distantPastValidator: optionalInvalidDateValidator(distantPastValidator),
         birthdate16YearsValidator: optionalInvalidDateValidator(birthdate16YearsValidator),
       },
-      personalHealthNumber: {},
+      personalHealthNumber: {
+        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator),
+      },
       socialInsuranceNumber: {},
       gender: {},
       citizenshipStatus: {},

--- a/jha/src/views/enrolment/PersonalInfoPage.vue
+++ b/jha/src/views/enrolment/PersonalInfoPage.vue
@@ -905,9 +905,7 @@ export default {
         distantPastValidator: optionalInvalidDateValidator(distantPastValidator),
         birthdate16YearsValidator: optionalInvalidDateValidator(birthdate16YearsValidator),
       },
-      personalHealthNumber: {
-        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator),
-      },
+      personalHealthNumber: {},
       socialInsuranceNumber: {},
       gender: {},
       citizenshipStatus: {},
@@ -944,6 +942,7 @@ export default {
     if (this.requestPersonalHealthNumber) {
       validations.personalHealthNumber.required = required;
       validations.personalHealthNumber.phnValidator = optionalValidator(phnValidator);
+      validations.personalHealthNumber.phnFirstDigitValidator = optionalValidator(phnFirstDigitValidator);
     }
 
     if (this.requestSocialInsuranceNumber) {

--- a/jha/src/views/enrolment/SpouseInfoPage.vue
+++ b/jha/src/views/enrolment/SpouseInfoPage.vue
@@ -107,7 +107,7 @@
               aria-live="assertive">Personal Health Number is required.</div>
             <div class="text-danger"
               v-if="$v.spousePersonalHealthNumber.$dirty
-                && !$v.spousePersonalHealthNumber.phnValidator"
+                && (!$v.spousePersonalHealthNumber.phnValidator || !$v.spousePersonalHealthNumber.phnFirstDigitValidator)"
               aria-live="assertive">Personal Health Number is invalid.</div>
           </div>
           <div v-if="requestSocialInsuranceNumber">
@@ -647,6 +647,7 @@ import {
   nonCanadaValidator,
   reasonDestinationContentValidator,
   pastDateValidator,
+  phnFirstDigitValidator
 } from '@/helpers/validators';
 import logService from '@/services/log-service';
 import {
@@ -939,7 +940,9 @@ export default {
         distantPastValidator: optionalValidator(distantPastValidator),
         birthDatePastValidator: optionalValidator(birthDatePastValidator),
       },
-      spousePersonalHealthNumber: {},
+      spousePersonalHealthNumber: {
+        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator)
+      },
       spouseSocialInsuranceNumber: {},
       spouseGender: {},
       spouseStatus: {},

--- a/jha/src/views/enrolment/SpouseInfoPage.vue
+++ b/jha/src/views/enrolment/SpouseInfoPage.vue
@@ -940,9 +940,7 @@ export default {
         distantPastValidator: optionalValidator(distantPastValidator),
         birthDatePastValidator: optionalValidator(birthDatePastValidator),
       },
-      spousePersonalHealthNumber: {
-        phnFirstDigitValidator: optionalValidator(phnFirstDigitValidator)
-      },
+      spousePersonalHealthNumber: {},
       spouseSocialInsuranceNumber: {},
       spouseGender: {},
       spouseStatus: {},
@@ -971,6 +969,7 @@ export default {
     if (this.requestPersonalHealthNumber) {
       validations.spousePersonalHealthNumber.required = required;
       validations.spousePersonalHealthNumber.phnValidator = optionalValidator(phnValidator);
+      validations.spousePersonalHealthNumber.phnFirstDigitValidator = optionalValidator(phnFirstDigitValidator);
     }
     
     if (this.requestSocialInsuranceNumber) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--Created new phnFirstDigitValidator that ensures that values passed to it must be strings, and must start with a 9
--Added this validator to the account holder, spouse, and child pages. Manually checked that they stop navigation if an error is present
--Added this validator to the error messages for all three pages

### Additional Notes:
