### PR TITLE
Fix navigate link in spouse edit page

### DIFF
--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -25,7 +25,7 @@
         <div v-if='showEditButtons'
             class="col-3 text-right">
           <a href="javascript:void(0)"
-            @click="navigateToMainFormPage()">Edit 
+            @click="navigateToSpouseInfoPage()">Edit 
             <font-awesome-icon icon="pencil-alt" />
           </a>
         </div>
@@ -890,6 +890,7 @@ export default {
       );
       pageStateService.setPageComplete(toPath);
       this.$router.push(toPath);
+      scrollTo();
     },
     navigateToChildInfoPage() {
         const toPath = getConvertedPath(
@@ -898,6 +899,7 @@ export default {
         );
         pageStateService.setPageComplete(toPath);
         this.$router.push(toPath);
+        scrollTo();
     },
     navigateToFPCInfoPage() {
       const toPath = getConvertedPath(
@@ -906,6 +908,7 @@ export default {
       );
       pageStateService.setPageComplete(toPath);
       this.$router.push(toPath);
+      scrollTo();
     },
     navigateToSuppBenInfoPage() {
       const toPath = getConvertedPath(
@@ -914,6 +917,7 @@ export default {
       );
       pageStateService.setPageComplete(toPath);
       this.$router.push(toPath);
+      scrollTo();
     },
     navigateToContactInfoPage() {
       const toPath = getConvertedPath(
@@ -922,6 +926,7 @@ export default {
       );
       pageStateService.setPageComplete(toPath);
       this.$router.push(toPath);
+      scrollTo();
     },
     getChildTitle(index) {
       const children = this.$store.state.enrolmentModule.children;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--changes navigateToMainForm call to navigateToSpouseInfoPage call, thus fixing the edit button
--also adds scrollTo() calls to this and other navigate functions, that way user starts at top of the page when they click the links
### Additional Notes:
Addresses bug ticket JHA-413. Manually tested