### PR TITLE
Review page bugs (JHA-452)

### DIFF
--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -258,12 +258,17 @@ export default {
                 ? "Yes"
                 : "No",
           });
-        const ahPreviousHealthNumber = this.$store.state.enrolmentModule
-          .ahPreviousHealthNumber;
-        items.push({
-          label: "Health number from previous residence",
-          value: ahPreviousHealthNumber ? ahPreviousHealthNumber : "No",
-        });
+        const ahCitizenshipStatus = this.$store.state.enrolmentModule.ahCitizenshipStatus;
+        if ((ahCitizenshipStatus === StatusInCanada.Citizen 
+          || ahCitizenshipStatus === StatusInCanada.PermanentResident)
+          && this.$store.state.enrolmentModule.ahCitizenshipStatusReason === CanadianStatusReasons.MovingFromProvince) {
+            const ahPreviousHealthNumber = this.$store.state.enrolmentModule
+              .ahPreviousHealthNumber;
+            items.push({
+              label: "Health number from previous residence",
+              value: ahPreviousHealthNumber ? ahPreviousHealthNumber : "No",
+            });
+        }
         items.push({
           label: "Has previous BC Health Number?",
           value:
@@ -469,12 +474,17 @@ export default {
               ? "Yes"
               : "No",
         });
-        const spousePreviousHealthNumber = this.$store.state.enrolmentModule
-          .spousePreviousHealthNumber;
-        items.push({
-          label: "Health number from previous residence",
-          value: spousePreviousHealthNumber ? spousePreviousHealthNumber : "No",
-        });
+        const spouseStatus = this.$store.state.enrolmentModule.spouseStatus;
+        if ((spouseStatus === StatusInCanada.Citizen 
+          || spouseStatus === StatusInCanada.PermanentResident)
+          && this.$store.state.enrolmentModule.spouseStatusReason === CanadianStatusReasons.MovingFromProvince) {
+            const spousePreviousHealthNumber = this.$store.state.enrolmentModule.spousePreviousHealthNumber;
+            items.push({
+              label: "Health number from previous residence",
+              value: spousePreviousHealthNumber ? spousePreviousHealthNumber : "No",
+            });
+        }
+        
         items.push({
           label: "Has Previous BC Health Number?",
           value:
@@ -650,7 +660,9 @@ export default {
               label: "Has child moved to BC permanently?",
               value: child.madePermanentMove === "Y" ? "Yes" : "No",
             });
-            if (child.previousHealthNumber) {
+            if ((child.status === StatusInCanada.Citizen 
+            || child.status === StatusInCanada.PermanentResident)
+            && child.statusReason === CanadianStatusReasons.MovingFromProvince) {
               childData.push({
                 label: "Health number from previous residence",
                 value: child.previousHealthNumber

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -226,6 +226,8 @@ export default {
           });
         }
         if (
+          this.$store.state.enrolmentModule.ahCitizenshipStatusReason !==
+            CanadianStatusReasons.LivingInBCWithoutMSP ||
           this.$store.state.enrolmentModule.ahHasLivedInBCSinceBirth !== "Y"
         ) {
           items.push({
@@ -247,7 +249,11 @@ export default {
             displayMoveFromLocation = this.$store.state.enrolmentModule.ahFromProvinceOrCountry;
           }
           items.push({
-            label: "Location account holder moved from",
+            label: this.getMoveFromLabel(
+              this.$store.state.enrolmentModule.ahCitizenshipStatus,
+              this.$store.state.enrolmentModule.ahCitizenshipStatusReason,
+              this.$store.state.enrolmentModule.ahHasLivedInBCSinceBirth
+            ),
             value: displayMoveFromLocation,
           });
         }
@@ -448,6 +454,8 @@ export default {
           });
         }
         if (
+          this.$store.state.enrolmentModule.spouseStatusReason !==
+            CanadianStatusReasons.LivingInBCWithoutMSP ||
           this.$store.state.enrolmentModule.spouseLivedInBCSinceBirth !== "Y"
         ) {
           items.push({
@@ -463,7 +471,11 @@ export default {
             ),
           });
           items.push({
-            label: "Location spouse moved from",
+            label: this.getMoveFromLabel(
+              this.$store.state.enrolmentModule.spouseStatus,
+              this.$store.state.enrolmentModule.spouseStatusReason,
+              this.$store.state.enrolmentModule.spouseLivedInBCSinceBirth
+            ),
             value: this.$store.state.enrolmentModule.spouseMoveFromOrigin,
           });
         }
@@ -643,7 +655,10 @@ export default {
               value: child.livedInBCSinceBirth === "Y" ? "Yes" : "No",
             });
           }
-          if (child.livedInBCSinceBirth !== "Y") {
+          if (
+            child.statusReason !== CanadianStatusReasons.LivingInBCWithoutMSP ||
+            child.livedInBCSinceBirth !== "Y"
+          ) {
             childData.push({
               label: "Date arrived in B.C.",
               value: formatDate(child.recentBCMoveDate),
@@ -653,7 +668,11 @@ export default {
               value: formatDate(child.canadaArrivalDate),
             });
             childData.push({
-              label: "Location child moved from",
+              label: this.getMoveFromLabel(
+                child.status,
+                child.statusReason,
+                child.livedInBCSinceBirth
+              ),
               value: child.moveFromOrigin,
             });
             childData.push({
@@ -1134,6 +1153,38 @@ export default {
         }
       }
       return "";
+    },
+    getMoveFromLabel(status, reason, livedInBC) {
+      //One of two conditions:
+      //1. Status reason is "Moving From Province" (combined with either Citizen or Permanent Resident status)
+      //2. Citizen status, "Living in BC Without MSP" reason, and "Lived in BC since birth" equals no
+      if (
+        ((status === StatusInCanada.Citizen ||
+          status === StatusInCanada.PermanentResident) &&
+          reason === CanadianStatusReasons.MovingFromProvince) ||
+        (status === StatusInCanada.Citizen &&
+          reason === CanadianStatusReasons.LivingInBCWithoutMSP &&
+          livedInBC === "N")
+      ) {
+        return "Moved from province";
+      }
+      //Status reason is "Moving From Jurisdiction" (combined with either Citizen or Permanent Resident status)
+      if (
+        (status === StatusInCanada.Citizen ||
+          status === StatusInCanada.PermanentResident) &&
+        reason === CanadianStatusReasons.MovingFromCountry
+      ) {
+        return "Moved from jurisdiction";
+      }
+      //Permanent Resident status and "Living in BC Without MSP" reason
+      if (
+        status === StatusInCanada.PermanentResident &&
+        reason === CanadianStatusReasons.LivingInBCWithoutMSP
+      ) {
+        return "Moved from province/jurisdiction";
+      }
+      //default
+      return "Moved from location";
     },
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--"Lived in BC Since Birth" now checks citizenship status/reason before displaying on review page (AH, Spouse, Child)
--"Moved From" label now changes to display province, jurisdiction, or province/jurisdiction based on the application (AH, Spouse, Child)
--Updated the logic that determines whether "Health number from previous residence" displays or not (AH, Spouse, Child)
--Added a getMoveFromLabel() function. It accepts three arguments (status, reason, livedInBCSinceBirth) and returns a string saying "Moved from province," "Moved from jurisdiction", "Moved from province/jurisdiction," or "Moved from location", per the requirements of the ticket

### Additional Notes:
Satisfies the requirements of JIRA ticket JHA-452. 
Also, the build action for my latest commit failed the first time due to an HTTP 500 error. I re-ran the action, and it worked the second time.
