### PR TITLE
Show permanent move info for any msp application

### DIFF
--- a/jha/src/components/ReviewTable.vue
+++ b/jha/src/components/ReviewTable.vue
@@ -15,7 +15,7 @@
 <script>
 
 export default {
-  name: 'Table',
+  name: 'ReviewTable',
   components: {},
   props: {
     elements: Array,

--- a/jha/src/components/enrolment/ReviewTableList.vue
+++ b/jha/src/components/enrolment/ReviewTableList.vue
@@ -733,6 +733,10 @@ export default {
               value: child.livedInBCSinceBirth === "Y" ? "Yes" : "No",
             });
           }
+          childData.push({
+            label: "Has child moved to BC permanently?",
+            value: child.madePermanentMove === "Y" ? "Yes" : "No",
+          });
           if (
             child.statusReason !== CanadianStatusReasons.LivingInBCWithoutMSP ||
             child.livedInBCSinceBirth !== "Y"
@@ -752,10 +756,6 @@ export default {
                 child.livedInBCSinceBirth
               ),
               value: child.moveFromOrigin,
-            });
-            childData.push({
-              label: "Has child moved to BC permanently?",
-              value: child.madePermanentMove === "Y" ? "Yes" : "No",
             });
             if ((child.status === StatusInCanada.Citizen 
             || child.status === StatusInCanada.PermanentResident)

--- a/jha/src/views/enrolment/ConsentPage.vue
+++ b/jha/src/views/enrolment/ConsentPage.vue
@@ -155,7 +155,7 @@ const requiredTrue = (value) => {
 };
 
 export default {
-  name: 'ReviewPage',
+  name: 'ConsentPage',
   mixins: [
     pageContentMixin,
     pageStepperMixin,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):

### Additional Notes:

Please double check the business logic here, I have changed the "Has permanently moved to bc" question to always show on the review page for an msp application's children. I believe this is correct since the logic to show the question always [returns true](https://github.com/bcgov/MOH-MSP-Enrolment/blob/main/jha/src/components/enrolment/Child.vue#L1735).

I also changed the name of two components to match the component filenames, added that in just because I find it helps when using the vue devtools and vscode
