### PR TITLE
default rdsp values to 0, api requires non-null value

### DIFF
--- a/jha/src/services/api-service.js
+++ b/jha/src/services/api-service.js
@@ -290,11 +290,11 @@ class ApiService {
         clientName: null,
         processDate: formatISODate(dateToday),
         accountHolderNetIncome: formState.ahFPCIncome,
-        accountHolderRDSP: formState.ahFPCRDSP || '0.00',
-        spouseNetIncome: formState.ahFPCIncome,
-        spouseRDSP: formState.ahFPCRDSP || '0.00',
+        accountHolderRDSP: formState.ahFPCRDSP || '0',
+        spouseNetIncome: formState.spouseFPCIncome || '0',
+        spouseRDSP: formState.spouseFPCRDSP || '0',
         spousePostalCode: postalCode,
-        persons, // Contains account holder, spouse, and children.
+        persons, 
         familyNumber: null,
         deductibleAmount: null, // TODO.
         annualMaximumAmount: null, // TODO.

--- a/jha/src/services/api-service.js
+++ b/jha/src/services/api-service.js
@@ -290,9 +290,9 @@ class ApiService {
         clientName: null,
         processDate: formatISODate(dateToday),
         accountHolderNetIncome: formState.ahFPCIncome,
-        accountHolderRDSP: formState.ahFPCRDSP,
+        accountHolderRDSP: formState.ahFPCRDSP || '0.00',
         spouseNetIncome: formState.ahFPCIncome,
-        spouseRDSP: formState.ahFPCRDSP,
+        spouseRDSP: formState.ahFPCRDSP || '0.00',
         spousePostalCode: postalCode,
         persons, // Contains account holder, spouse, and children.
         familyNumber: null,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):

Bug fix

### Additional Notes:

The api was giving a malformed error if the value for the account holder rdsp or spouse rdsp is null. I defaulted it at the `api-service` level to 0. 

We could alternatively default it at the `vuex` store as well, which would pre-fill the input with 0. I decided to go this way to have the UI more consistent with how income is handled (field is not pre-filled).

I had a question while looking at this, is there a business logic reason that `spouseRDSP` gets set as the account holders RDSP? I wasn't sure so kept it the same