### PR TITLE
Use correct children array for fpcare

### DIFF
--- a/jha/src/services/api-service.js
+++ b/jha/src/services/api-service.js
@@ -274,7 +274,7 @@ class ApiService {
     if (formState.isApplyingForFPCare) {
       const postalCode = formState.isMailSame && formState.resPostalCode ? stripSpaces(formState.resPostalCode) : stripSpaces(formState.mailPostalCode);
       const persons = [];
-      children.forEach((child) => {
+      formState.children.forEach((child) => {
         persons.push({
           givenName: child.firstName,
           surname: child.lastName,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Unit tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Bug fix
 
### Additional Notes:
the previous `children` array filtered based on the childAgeRange which isn't used in FPCare-only submissions so it was always empty. `formState.children` contains the original array with all children