### PR TITLE
change key name for child's phn

### DIFF
--- a/jha/src/services/api-service.js
+++ b/jha/src/services/api-service.js
@@ -288,7 +288,7 @@ class ApiService {
           postalCode: postalCode,
           perType: '2', // 0 is applicant, 1 is spouse, 2 is children only.
           dateOfBirth: formatISODate(child.birthDate),
-          phn: stripSpaces(child.phn) || null,
+          phn: stripSpaces(child.personalHealthNumber) || null,
         });
       });
       


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [x] Unit tests for these changes were added (if applicable)
- [x] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Bug fix
### Additional Notes:
vuex state saves children's phn as `personalHealthNumber` 
