### PR TITLE
Update node version in JHA (12 -> 18, 22)

### DIFF
--- a/.github/workflows/jha-web.yaml
+++ b/.github/workflows/jha-web.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: [test]
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [18.x, 22.x]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/jha/openshift/templates/build.yaml
+++ b/jha/openshift/templates/build.yaml
@@ -62,15 +62,23 @@ objects:
       type: Git
     strategy:
       sourceStrategy:
-        env:
-        - name: BUILD_LOGLEVEL
-          value: "5"
         from:
-          kind: ImageStreamTag
-          name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
-          namespace: ${SOURCE_IMAGE_NAMESPACE}
+          kind: DockerImage
+          name: registry.redhat.io/ubi9/nodejs-18
+        env:
+          - name: BUILD_LOGLEVEL
+            value: "5"
         incremental: false
-      type: Source
+      # sourceStrategy:
+      #   env:
+      #   - name: BUILD_LOGLEVEL
+      #     value: "5"
+      #   from:
+      #     kind: ImageStreamTag
+      #     name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
+      #     namespace: ${SOURCE_IMAGE_NAMESPACE}
+      #   incremental: false
+      # type: Source
     # triggers:
     # - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [x] `npm audit` was checked, applicable vulnerabilities were updated
- [x] `npm run build` passes
- [x] `npm run lint` has no unexpected errors
- [ ] `npm run format` was run on changed files
- [x] All existing unit tests were run and still pass
- [x] End-to-end tests were run and still pass (`npm run test:e2e:headless`)


### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Updates build matrix in jha-web workflow to use both 18 and 22. 

Update source strategy in build.yaml to use nodejs-18 rather than 12. (It's preferable to run JHA in 22 where possible for maximum compatibility with the pdf-js package, but it will build in 18, and that'll do for now while we wait for 22 to go into LTS and eventually become an image in the Redhat registry. Both of those options are better than 12, which fails everywhere.) 

This change was manually added to OpenShift as well.

In summary:
Local development-- use node 22
jha-web.yaml Test step-- runs unit/e2e tests in 22 (node 18 can't properly run the unit tests due to pdf-js compatibility, but the application works fine in the browser and the tests pass in node 22)
jha-web.yaml Build step-- runs in 18 and 22 (should pass in both)
jha-web.yaml Image-build action-- set to nodejs-18 in the build.yaml and OpenShift (planned to upgrade to 22 when the LTS image becomes available)

### Additional Notes:
`npm run format` changes will happen at a later date.